### PR TITLE
add DisplaySpecs::COLUMN_OFFSET

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ impl DisplaySpecs<132, 32, 4> for DOGM132W5 {
     const VOLTAGE_REGULATOR_RESISTOR_RATIO: u8 = 0b011;
     const ELECTRONIC_VOLUME: u8 = 0b011111;
     const BOOSTER_RATIO: BoosterRatio = BoosterRatio::StepUp2x3x4x;
+    const COLUMN_OFFSET: u8 = 0;
 }
 ```
 

--- a/src/display_specs.rs
+++ b/src/display_specs.rs
@@ -35,4 +35,7 @@ pub trait DisplaySpecs<const WIDTH: usize, const HEIGHT: usize, const PAGES: usi
 
     /// The internal booster ratio
     const BOOSTER_RATIO: BoosterRatio;
+
+    /// The offset of the first column on the display
+    const COLUMN_OFFSET: u8;
 }

--- a/src/displays/mod.rs
+++ b/src/displays/mod.rs
@@ -20,6 +20,7 @@ impl DisplaySpecs<132, 32, 4> for DOGM132W5 {
     const VOLTAGE_REGULATOR_RESISTOR_RATIO: u8 = 0b011;
     const ELECTRONIC_VOLUME: u8 = 0b011111;
     const BOOSTER_RATIO: BoosterRatio = BoosterRatio::StepUp2x3x4x;
+    const COLUMN_OFFSET: u8 = 0;
 }
 
 /// Display specification for the DOGL128-6 display
@@ -38,6 +39,7 @@ impl DisplaySpecs<132, 64, 8> for DOGL128_6_EXT12V {
     const VOLTAGE_REGULATOR_RESISTOR_RATIO: u8 = 0b100111;
     const ELECTRONIC_VOLUME: u8 = 0b010110;
     const BOOSTER_RATIO: BoosterRatio = BoosterRatio::StepUp2x3x4x;
+    const COLUMN_OFFSET: u8 = 0;
 }
 
 /// Display specification for the GM12864-06D Ver. 2.2 display.
@@ -55,4 +57,5 @@ impl DisplaySpecs<132, 64, 8> for GMG12864 {
     const VOLTAGE_REGULATOR_RESISTOR_RATIO: u8 = 0b111;
     const ELECTRONIC_VOLUME: u8 = 0b010001;
     const BOOSTER_RATIO: BoosterRatio = BoosterRatio::StepUp2x3x4x;
+    const COLUMN_OFFSET: u8 = 0;
 }

--- a/src/displays/mod.rs
+++ b/src/displays/mod.rs
@@ -26,7 +26,7 @@ impl DisplaySpecs<132, 32, 4> for DOGM132W5 {
 /// Display specification for the DOGL128-6 display
 #[allow(non_camel_case_types)]
 pub struct DOGL128_6_EXT12V;
-impl DisplaySpecs<132, 64, 8> for DOGL128_6_EXT12V {
+impl DisplaySpecs<128, 64, 8> for DOGL128_6_EXT12V {
     const FLIP_ROWS: bool = true;
     const FLIP_COLUMNS: bool = false;
     const INVERTED: bool = false;
@@ -39,7 +39,7 @@ impl DisplaySpecs<132, 64, 8> for DOGL128_6_EXT12V {
     const VOLTAGE_REGULATOR_RESISTOR_RATIO: u8 = 0b100111;
     const ELECTRONIC_VOLUME: u8 = 0b010110;
     const BOOSTER_RATIO: BoosterRatio = BoosterRatio::StepUp2x3x4x;
-    const COLUMN_OFFSET: u8 = 0;
+    const COLUMN_OFFSET: u8 = 4;
 }
 
 /// Display specification for the GM12864-06D Ver. 2.2 display.

--- a/src/driver/mode_graphics.rs
+++ b/src/driver/mode_graphics.rs
@@ -31,7 +31,7 @@ impl<'a, const WIDTH: usize, const PAGES: usize> GraphicsMode<'a, WIDTH, PAGES> 
 impl<
         'a,
         DI: WriteOnlyDataCommand,
-        SPECS,
+        SPECS: DisplaySpecs<WIDTH, HEIGHT, PAGES>,
         const WIDTH: usize,
         const HEIGHT: usize,
         const PAGES: usize,
@@ -49,7 +49,7 @@ impl<
                     self.interface
                         .send_command(Command::PageAddressSet { address })?;
                     self.interface.send_command(Command::ColumnAddressSet {
-                        address: start as u8,
+                        address: SPECS::COLUMN_OFFSET + start as u8,
                     })?;
                     self.interface.send_data(U8(&page.data[start..end]))?;
                 }


### PR DESCRIPTION
As discussed in #18, some displays start on a non-zero column address. It looks like this has something to do with `FLIP_COLUMNS` putting columns that used to be off the screen on the high end down into the low addresses.

This PR adds a `COLUMN_OFFSET` parameter added to every `Command::ColumnAddressSet` in graphics mode.

Some notes:
 * I had to add a `SPECS: DisplaySpec<..>` constraint to an impl block. You can't get a graphics mode interface without that constraint, but it is technically an API break for anyone doing something naughty with transmute.
 * Every display spec needs a new `COLUMN_OFFSET` const, which is also an API break. I considered making this default to 0, but no other field has defaults.
 * I have not modified the spec for `DOGL128_6_EXT12V` except to add a 0 offset. This should probably be 4, but I don't have the display and can't test it. (cc: @deltronix)
 * Despite my best efforts, I can't get the tests to run. But the examples compile, and it fixes the particular display I was working on.