### PR TITLE
Set line offset

### DIFF
--- a/src/driver/common_functionality.rs
+++ b/src/driver/common_functionality.rs
@@ -26,6 +26,24 @@ where
             .send_command(Command::StaticIndicatorSet { mode })
     }
 
+    /// Sets the line offset, effectively scrolling the display through memory.
+    pub fn set_line_offset(&mut self, offset: u8) -> Result<(), DisplayError> {
+        self.interface
+            .send_command(Command::DisplayStartLineSet { address: offset })
+    }
+
+    /// Sets whether the pixels should be inverted.
+    pub fn set_inverted(&mut self, inverted: bool) -> Result<(), DisplayError> {
+        self.interface
+            .send_command(Command::DisplayNormalReverse { reverse: inverted })
+    }
+
+    /// Displays all points of the display
+    pub fn display_all_points(&mut self, enable: bool) -> Result<(), DisplayError> {
+        self.interface
+            .send_command(Command::DisplayAllPoints { on: enable })
+    }
+
     /// Enable/Disable the display output
     pub fn set_display_on(&mut self, on: bool) -> Result<(), DisplayError> {
         self.interface.send_command(Command::DisplayOnOff { on })

--- a/src/driver/common_functionality.rs
+++ b/src/driver/common_functionality.rs
@@ -105,6 +105,11 @@ where
             })
             .map_err(Error::Comm)?;
 
+        // some ICs do not reset line offset to 0, so do that here as well
+        self.interface
+            .send_command(Command::DisplayStartLineSet { address: 0 })
+            .map_err(Error::Comm)?;
+
         Ok(())
     }
 }

--- a/src/driver/mode_raw.rs
+++ b/src/driver/mode_raw.rs
@@ -28,18 +28,6 @@ where
             .send_command(Command::ColumnAddressSet { address })
     }
 
-    /// Sets the line offset, effectively scrolling the display through memory.
-    pub fn set_line_offset(&mut self, offset: u8) -> Result<(), DisplayError> {
-        self.interface
-            .send_command(Command::DisplayStartLineSet { address: offset })
-    }
-
-    /// Sets whether the pixels should be inverted.
-    pub fn set_inverted(&mut self, inverted: bool) -> Result<(), DisplayError> {
-        self.interface
-            .send_command(Command::DisplayNormalReverse { reverse: inverted })
-    }
-
     /// Writes raw pixel data.
     ///
     /// For more information how data is processed by the display, read the
@@ -61,11 +49,5 @@ where
     pub fn common_output_mode_select(&mut self, reverse: bool) -> Result<(), DisplayError> {
         self.interface
             .send_command(Command::CommonOutputModeSelect { reverse })
-    }
-
-    /// Displays all points of the display
-    pub fn display_all_points(&mut self, enable: bool) -> Result<(), DisplayError> {
-        self.interface
-            .send_command(Command::DisplayAllPoints { on: enable })
     }
 }


### PR DESCRIPTION
As discussed in #21.

First commit simply sets the line offset to 0 manually in `reset()`.

Second commit conservatively exposes some commands to all modes. I left the commands most likely to cause issues if misused in raw mode. Now available in all modes:
 * `set_line_offset`
 * `set_inverted`
 * `display_all_points`

The first commit is semver compatible, the second commit technically isn't (but only to people who somehow obtained an `St7565` without calling `new()`). Feel free to merge as much as you feel comfortable with.